### PR TITLE
replace Nothing by Void

### DIFF
--- a/core/src/main/scala/com/softwaremill/sockets/UsingZio.scala
+++ b/core/src/main/scala/com/softwaremill/sockets/UsingZio.scala
@@ -72,7 +72,7 @@ object UsingZio extends StrictLogging {
 
   def clientSend(socket: ConnectedSocket, parent: IOQueue[RouterMessage], sendQueue: IOQueue[String]): IO[Nothing, Fiber[Unit, Unit]] =
     sendQueue
-      .take[Nothing]
+      .take[scalaz.zio.Void]
       .widenError[Throwable]
       .flatMap(msg => IO.syncThrowable(socket.send(msg)))
       .attempt[Unit]

--- a/core/src/main/scala/com/softwaremill/supervise/UsingZio.scala
+++ b/core/src/main/scala/com/softwaremill/supervise/UsingZio.scala
@@ -8,26 +8,26 @@ import com.softwaremill.IOInstances._
 object UsingZio extends StrictLogging {
 
   sealed trait BroadcastMessage
-  case class Subscribe(consumer: String => IO[Nothing, Unit]) extends BroadcastMessage
+  case class Subscribe(consumer: String => IO[scalaz.zio.Void, Unit]) extends BroadcastMessage
   case class Received(msg: String) extends BroadcastMessage
 
-  case class BroadcastResult(inbox: IOQueue[BroadcastMessage], cancel: IO[Nothing, Unit])
+  case class BroadcastResult(inbox: IOQueue[BroadcastMessage], cancel: IO[scalaz.zio.Void, Unit])
 
-  def broadcast(connector: QueueConnector[IO[Throwable, ?]]): IO[Nothing, BroadcastResult] = {
-    def processMessages(inbox: IOQueue[BroadcastMessage], consumers: Set[String => IO[Nothing, Unit]]): IO[Nothing, Unit] =
+  def broadcast(connector: QueueConnector[IO[Throwable, ?]]): IO[scalaz.zio.Void, BroadcastResult] = {
+    def processMessages(inbox: IOQueue[BroadcastMessage], consumers: Set[String => IO[scalaz.zio.Void, Unit]]): IO[scalaz.zio.Void, Unit] =
       inbox
-        .take[Nothing]
+        .take[scalaz.zio.Void]
         .flatMap {
           case Subscribe(consumer) => processMessages(inbox, consumers + consumer)
           case Received(msg) =>
             consumers
-              .map(consumer => consumer(msg).fork[Nothing])
+              .map(consumer => consumer(msg).fork[scalaz.zio.Void])
               .toList
               .sequence_
               .flatMap(_ => processMessages(inbox, consumers))
         }
 
-    def consumeForever(inbox: IOQueue[BroadcastMessage]): IO[Nothing, Unit] =
+    def consumeForever(inbox: IOQueue[BroadcastMessage]): IO[scalaz.zio.Void, Unit] =
       consume(connector, inbox).attempt.map {
         case Left(e) =>
           logger.info("[broadcast] exception in queue consumer, restarting", e)
@@ -36,10 +36,10 @@ object UsingZio extends StrictLogging {
       }.forever
 
     for {
-      inbox <- IOQueue.make[Nothing, BroadcastMessage](32)
-      f1 <- consumeForever(inbox).fork[Nothing]
-      f2 <- processMessages(inbox, Set()).fork[Nothing]
-    } yield BroadcastResult(inbox, f1.interrupt[Nothing](new RuntimeException) *> f2.interrupt(new RuntimeException))
+      inbox <- IOQueue.make[scalaz.zio.Void, BroadcastMessage](32)
+      f1 <- consumeForever(inbox).fork[scalaz.zio.Void]
+      f2 <- processMessages(inbox, Set()).fork[scalaz.zio.Void]
+    } yield BroadcastResult(inbox, f1.interrupt[scalaz.zio.Void](new RuntimeException) *> f2.interrupt(new RuntimeException))
   }
 
   def consume(connector: QueueConnector[IO[Throwable, ?]], inbox: IOQueue[BroadcastMessage]): IO[Throwable, Unit] = {
@@ -57,11 +57,11 @@ object UsingZio extends StrictLogging {
         .flatMap(msg => inbox.offer(Received(msg)))
         .forever
 
-    def releaseQueue(queue: Queue[IO[Throwable, ?]]): IO[Nothing, Unit] =
+    def releaseQueue(queue: Queue[IO[Throwable, ?]]): IO[scalaz.zio.Void, Unit] =
       IO.syncThrowable(logger.info("[queue-stop] closing"))
         .flatMap(_ => queue.close())
         .map(_ => logger.info("[queue-stop] closed"))
-        .catchAll[Nothing](e => IO.now(logger.info("[queue-stop] exception while closing", e)))
+        .catchAll[scalaz.zio.Void](e => IO.now(logger.info("[queue-stop] exception while closing", e)))
 
     connect.bracket(releaseQueue)(consumeQueue)
   }

--- a/core/src/test/scala/com/softwaremill/supervise/ZioSuperviseTest.scala
+++ b/core/src/test/scala/com/softwaremill/supervise/ZioSuperviseTest.scala
@@ -29,7 +29,7 @@ class ZioSuperviseTest
 
     val t = for {
       br <- UsingZio.broadcast(testData.queueConnector)
-      _ <- br.inbox.offer[Nothing](UsingZio.Subscribe(msg => IO.sync(receivedMessages.add(msg))))
+      _ <- br.inbox.offer[scalaz.zio.Void](UsingZio.Subscribe(msg => IO.sync(receivedMessages.add(msg))))
       _ <- IO
         .sync {
           eventually {


### PR DESCRIPTION
sbt compile generates this error

`akka-vs-scalaz/core/src/main/scala/com/softwaremill/supervise/UsingZio.scala:66:21: type mismatch;
[error]  found   : scalaz.zio.IO[Nothing,Unit]
[error]  required: scalaz.zio.Infallible[Unit]
[error]     (which expands to)  scalaz.zio.IO[scalaz.zio.Void,Unit]
[error]     connect.bracket(releaseQueue)(consumeQueue)`

Replacing Nothing by Void resolves the compilation issues.

There are runtime failures from the tests, so further work is evidently required